### PR TITLE
struct Timeout -> TimeoutController

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ let val = try await withThrowingTimeout(seconds: 2.0) {
 
 > Note: When the timeout expires the task executing the closure is cancelled and `TimeoutError` is thrown.
 
-An overload includes a `Timeout` object allowing the body to cancel or move the expiration where required:
+An overload includes a `TimeoutController` object allowing the body to cancel or move the expiration where required:
 
 ```swift
 try await withThrowingTimeout(seconds: 1.0) { timeout in

--- a/Sources/Timeout.swift
+++ b/Sources/Timeout.swift
@@ -32,7 +32,10 @@
 #if compiler(>=6.0)
 import Foundation
 
-public struct Timeout: Sendable {
+@available(*, unavailable, renamed: "TimeoutController")
+public typealias Timeout = TimeoutController
+
+public struct TimeoutController: Sendable {
     fileprivate var canary: @Sendable () -> Void
     fileprivate let shared: SharedState
 
@@ -74,7 +77,7 @@ public struct Timeout: Sendable {
 }
 
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
-public extension Timeout {
+public extension TimeoutController {
 
     @discardableResult
     func expire<C: Clock>(
@@ -97,7 +100,7 @@ public extension Timeout {
     }
 }
 
-extension Timeout {
+extension TimeoutController {
 
     init(
         canary: @escaping @Sendable () -> Void,
@@ -156,13 +159,13 @@ extension Timeout {
 func withNonEscapingTimeout<T>(
     _ timeout: @escaping @Sendable () async throws -> Never,
     isolation: isolated (any Actor)? = #isolation,
-    body: (Timeout) async throws -> sending T
+    body: (TimeoutController) async throws -> sending T
 ) async throws -> sending T {
     // canary ensuring Timeout does not escape at runtime.
     // Swift 6.2 and later enforce at compile time with ~Escapable
     try await withoutActuallyEscaping({ @Sendable in }) { escaping in
         _ = isolation
-        let timeout = Timeout(canary: escaping, pending: timeout)
+        let timeout = TimeoutController(canary: escaping, pending: timeout)
         return try await Transferring(body(timeout))
     }.value
 }

--- a/Sources/withThrowingTimeout.swift
+++ b/Sources/withThrowingTimeout.swift
@@ -54,7 +54,7 @@ public func withThrowingTimeout<T>(
 public func withThrowingTimeout<T>(
     isolation: isolated (any Actor)? = #isolation,
     seconds: TimeInterval,
-    body: (Timeout) async throws -> sending T
+    body: (TimeoutController) async throws -> sending T
 ) async throws -> sending T {
     try await _withThrowingTimeout(isolation: isolation, body: body) {
         try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
@@ -91,7 +91,7 @@ public func withThrowingTimeout<T>(
 
 private func _withThrowingTimeout<T>(
     isolation: isolated (any Actor)? = #isolation,
-    body: (Timeout) async throws -> sending T,
+    body: (TimeoutController) async throws -> sending T,
     timeout closure: @Sendable @escaping () async throws -> Never
 ) async throws -> Transferring<T> {
     try await withoutActuallyEscaping(body) { escapingBody in


### PR DESCRIPTION
Renames the recently added `struct Timeout` to `TimeoutController` to better represent its purpose and avoid a namespace collision with the module `Timeout` from #6 .